### PR TITLE
Improve debian install scripts

### DIFF
--- a/scripts/build_kvm_image.sh
+++ b/scripts/build_kvm_image.sh
@@ -49,7 +49,7 @@ prepare_installer_disk()
     umount $tmpdir
 }
 
-apt-get install -y net-tools
+DEBIAN_FRONTEND=noninteractive apt-get -qq -y install net-tools
 create_disk
 prepare_installer_disk
 
@@ -84,7 +84,7 @@ trap on_error ERR
 
 kvm_pid=$!
 
-sleep 2.0
+sleep 2
 
 [ -d "/proc/$kvm_pid" ] || {
         echo "ERROR: kvm died."

--- a/scripts/prepare_slave_container_buildinfo.sh
+++ b/scripts/prepare_slave_container_buildinfo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SLAVE_DIR=$1
 ARCH=$2
@@ -16,7 +16,7 @@ cp -rf $SLAVE_DIR/buildinfo/* /usr/local/share/buildinfo/
 
 # Enable reproducible mirrors
 set_reproducible_mirrors
-apt-get update > /dev/null 2>&1
+DEBIAN_FRONTEND=noninteractive apt-get -qq update > /dev/null 2>&1
 
 # Build the slave version config
 [ -d /usr/local/share/buildinfo/versions ] && rm -rf /usr/local/share/buildinfo/versions
@@ -24,5 +24,5 @@ scripts/versions_manager.py generate -t "/usr/local/share/buildinfo/versions" -n
 touch ${BUILDINFO_PATH}/versions/versions-deb
 
 rm -f /etc/apt/preferences.d/01-versions-deb
-([ "$ENABLE_VERSION_CONTROL_DEB" == "y" ] && [ -f $VERSION_DEB_PREFERENCE ]) && cp -f $VERSION_DEB_PREFERENCE /etc/apt/preferences.d/
+([ "$ENABLE_VERSION_CONTROL_DEB" = "y" ] && [ -f $VERSION_DEB_PREFERENCE ]) && cp -f $VERSION_DEB_PREFERENCE /etc/apt/preferences.d/
 exit 0


### PR DESCRIPTION
Though bash is a good interactive user shell,
many UN*X systems and GNU+Linux distributions now prefers Almquist
or Kornshell variants for scripting in order to improve the system
performance and maintenability.

https://wiki.ubuntu.com/DashAsBinSh
https://mywiki.wooledge.org/Bashism
https://en.wikipedia.org/wiki/Almquist_shell

apt-get commands are non interactive when run during the installation
process and especially inside chroot environment.
This can be specified by the right environment variable to apt-get.
Most output has no added value here and can also be partially disabled
with option -qq.
This option cannot completely prevent dpkg from displaying a few output.

- Remove most bashisms
- remove useless output from debian apt-get calls
- Do some refactoring

Signed-off-by: Guillaume Lambert <guillaume.lambert@orange.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

#### How I did it

#### How to verify it

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/SONiC/wiki/Configuration.
-->

#### A picture of a cute animal (not mandatory but encouraged)

